### PR TITLE
Compatability with parent method

### DIFF
--- a/src/EloquentSti/SingleTableInheritanceTrait.php
+++ b/src/EloquentSti/SingleTableInheritanceTrait.php
@@ -61,7 +61,7 @@ trait SingleTableInheritanceTrait
      * @param  array $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function newFromBuilder($attributes = array())
+    public function newFromBuilder($attributes = array(), $connection = NULL)
     {
         // Create a new instance of the Entity Type Class
         $m = $this->mapData((array)$attributes)->newInstance(array(), true);


### PR DESCRIPTION
`Declaration of MyApp\SingleTableInheritanceTrait::newFromBuilder() should be compatible with Illuminate\Database\Eloquent\Model::newFromBuilder($attributes = Array, $connection = NULL)`

This fixed this problem for me. 

P.S. I have re-namespaced it for the moment because it won't autoload for some reason.
